### PR TITLE
Add vanilla auth handler for default Logz ver

### DIFF
--- a/testing.go
+++ b/testing.go
@@ -1,12 +1,13 @@
 package kibana
 
 import (
-	"github.com/parnurzeal/gorequest"
-	"gopkg.in/ory-am/dockertest.v3"
 	"log"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/parnurzeal/gorequest"
+	"gopkg.in/ory-am/dockertest.v3"
 )
 
 type testContext struct {
@@ -24,7 +25,10 @@ var authForContainerVersion = map[string]map[KibanaType]AuthenticationHandler{
 		KibanaTypeVanilla: &BasicAuthenticationHandler{"elastic", "changeme"},
 		KibanaTypeLogzio:  createLogzAuthenticationHandler(),
 	},
-	DefaultLogzioVersion:  {KibanaTypeLogzio: createLogzAuthenticationHandler()},
+	DefaultLogzioVersion: {
+		KibanaTypeLogzio:  createLogzAuthenticationHandler(),
+		KibanaTypeVanilla: &NoAuthenticationHandler{},
+	},
 	DefaultKibanaVersion6: {KibanaTypeVanilla: &NoAuthenticationHandler{}},
 }
 


### PR DESCRIPTION
* When the Kibana version is coincidentally the default Logz version, we
do not set a KibanaTypeVanilla auth handler. This results in panics when
version is 6.3.2 but the Kibana type is vanilla.

Signed-off-by: Brendan Devenney <brendan.devenney@form3.tech>