### PR TITLE
Add support for kibana 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: go
 go:
 - 1.9
@@ -5,10 +6,11 @@ services:
 - docker
 env:
   matrix:
-  - ELK_VERSION=5.5.3   KIBANA_TYPE=KibanaTypeVanilla   ELASTIC_PACK=
-  - ELK_VERSION=6.3.2   KIBANA_TYPE=KibanaTypeLogzio    KIBANA_URI=https://app-eu.logz.io    ELASTIC_SEARCH_PATH=/kibana/elasticsearch/logzioCustomerKibanaIndex  LOGZ_IO_ACCOUNT_ID_1=16533  LOGZ_IO_ACCOUNT_ID_2=14942
-  - ELK_VERSION=6.2.1   KIBANA_TYPE=KibanaTypeVanilla
-  - ELK_VERSION=6.4.1   KIBANA_TYPE=KibanaTypeVanilla
+  - ELK_VERSION=5.5.3 KIBANA_TYPE=KibanaTypeVanilla ELASTIC_PACK= MAKELOGS_VERSION=makelogs@4.0.3
+  - ELK_VERSION=6.3.2 KIBANA_TYPE=KibanaTypeLogzio KIBANA_URI=https://app-eu.logz.io ELASTIC_SEARCH_PATH=/kibana/elasticsearch/logzioCustomerKibanaIndex LOGZ_IO_ACCOUNT_ID_1=16533 LOGZ_IO_ACCOUNT_ID_2=14942
+  - ELK_VERSION=6.2.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=makelogs@4.0.3
+  - ELK_VERSION=6.4.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=makelogs@4.0.3
+  - ELK_VERSION=7.3.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=@elastic/makelogs@4.5.0
   global:
   - secure: THmTeSKm985JY3VKqgoFXCp4SIdrHfQv9CzS3K4ifH5NalhMOIPyI+PbBCPCSZ+zF1JcbziI9bWKBJcF/7aUlHdlUytnT/d3JkZ4QOkxtm5qgcFvoaPTswpUCYhtcLKx7FJ6d9szpsOZn+NZNA15/GNQfT38/BbhiJ0+aaGRtnxjEBoNl97lmds1EneAzT67kHabkr7N9qgysGkyIlmqjpuwpobERLmVdKJoaSWganGfzMECcOThdI8T0byq19CmFhBe2Xz5/DMTQD7leFX45AHghlfKrLLMeyTm0A2WfF8e368FDDRA2qRZgDivE+0kB+lGZ+s3+hO3svOfDEImG+1RkjSuy1cICrjNEGEaROAvn2MKucc55VQaEX5744mzwdXDkGM/L9E3gHYGBF5wEwCiBDIsdZBM4zWy+jKYDLmjEIXANNLYWP7VrwMMILTtEY6alqb4f9IBgPArDc3e0VSIBemv30rItxQRKq4grcfd9dI8SugqXWrNDdVUoBJg6ka8/fZYeu3uQByXcnXhgNY59ScN1J9P9I1JFKMrr9XYCq0bB0lGh+rYSNimkvkRwWHGqvpaM871zM3cIJbqF1qbRIJut49oI64B5f2nj+G3sGHoe0QcsDmwWO2+9HRN4fR6Y50b4MvRdr53ipPGkdQJpTMKlCgsHrYNp56b6U8=
   - secure: LxqVNnGMuWvSJRivWydC5fHFvh4XY+6wxg1nGogu88eZ3f271mnqsz3BZd/3RyEXl/t42PvjEYRHkgIh4cOtrHGRKMvvOwTY+e5ho4SIWpoqm+gbNXvHEg9UdrzRM7eyvvtpitx3pYYAq5vcMcIGHUZu0ic84cPGWoZKuz0cPJaeZfAlwgq+jQVx8LAkxbip8z/jr2jn5wyMv8PIb4W0pbm3oqFEurQAcQhAIeiWnyZnTbgkvDIleeiwB95ouFn8kERkQvFPScVtuYJILjDk9W+79aOiGEgk8wOVvzZw8lZ1/EzfCorFG468Fu2QeB8jHPr8dG4omshoKFylVFXGzguOCeJ384gGCPJYwwSDCDTbk3F0jeI/VGjBcfcfAhb/9FrKcby/b8f4/w3PQv6oq9dewoRA5OOx+2duuO9B5Gz2rz7wQiXKoVYr+/5j6Xg7B4aFipJ/Z/AfebPqAftjOWJJr2w9dxSq3FZh3j/ZxlbgVe87/AvpWKsdHwz8qlz4ncD5GgbZl2clzbXYk7/h54kZ/86695qu4adTopKRsBlOFAoCtuGDUPcDU4TjmtJcHHGesSyjANcn7hSjAqJktVKPQvmcXHAJhHO/Y9Tw8pRReKyUGDD30yNd2+bauLAiuV5+PKfJLr4j+H0P3nPy8K5XsOcjDAA8Wo+6Tr+lISA=

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ docker-build:
 		exit 1; \
 	fi
 	@if [ "$(KIBANA_TYPE)" = "KibanaTypeVanilla" ]; then \
-		cd docker/elasticsearch && docker build --build-arg ELK_VERSION=$(ELK_VERSION) --build-arg ELK_PACK=$(ELK_PACK) . -t elastic-local:$(ELK_VERSION); \
+		cd docker/elasticsearch && docker build --no-cache --build-arg ELK_VERSION=$(ELK_VERSION) --build-arg MAKELOGS_VERSION=$(MAKELOGS_VERSION) --build-arg ELK_PACK=$(ELK_PACK) . -t elastic-local:$(ELK_VERSION); \
 	fi
 
 kibana-start: docker-build

--- a/dashboard.go
+++ b/dashboard.go
@@ -25,7 +25,7 @@ type UpdateDashboardRequest struct {
 type Dashboard struct {
 	Id         string               `json:"id"`
 	Type       string               `json:"type"`
-	Version    int                  `json:"version"`
+	Version    version              `json:"version"`
 	Attributes *DashboardAttributes `json:"attributes"`
 }
 
@@ -35,7 +35,7 @@ type DashboardAttributes struct {
 	Version               int                          `json:"version"`
 	PanelsJson            string                       `json:"panelsJSON"`
 	OptionsJson           string                       `json:"optionsJSON"`
-	UiStateJSON           string                       `json:"uiStateJSON"`
+	UiStateJSON           string                       `json:"uiStateJSON,omitempty"`
 	TimeRestore           bool                         `json:"timeRestore"`
 	KibanaSavedObjectMeta *SearchKibanaSavedObjectMeta `json:"kibanaSavedObjectMeta"`
 }
@@ -63,7 +63,7 @@ type dashboardClient553 struct {
 type dashboardReadResult553 struct {
 	Id      string               `json:"_id"`
 	Type    string               `json:"_type"`
-	Version int                  `json:"_version"`
+	Version version              `json:"_version"`
 	Source  *DashboardAttributes `json:"_source"`
 }
 

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -2,9 +2,10 @@ package kibana
 
 import (
 	"fmt"
-	"github.com/satori/go.uuid"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_DashboardCreateFromSavedSearch(t *testing.T) {
@@ -24,11 +25,13 @@ func Test_DashboardCreateFromSavedSearch(t *testing.T) {
 		WithDescription("This visualization shows errors from china").
 		WithVisualizationState("{\"title\":\"test kong vis\",\"type\":\"area\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp date ranges\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_range\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"ranges\":[{\"from\":\"now-1h\",\"to\":\"now\"}]}}],\"listeners\":{}}").
 		WithSavedSearchId(searchResponse.Id).
-		Build()
+		Build(client.Config.KibanaVersion)
 
 	assert.Nil(t, err)
 
 	visualizationResponse, err := visualizationApi.Create(visualizationRequest)
+	assert.Nil(t, err)
+
 	defer visualizationApi.Delete(visualizationResponse.Id)
 
 	dashboardApi := client.Dashboard()
@@ -38,12 +41,13 @@ func Test_DashboardCreateFromSavedSearch(t *testing.T) {
 		WithDescription("This dashboard shows errors from china").
 		WithPanelsJson(fmt.Sprintf("[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"%s\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"search\",\"id\":\"%s\",\"col\":7,\"row\":1,\"columns\":[\"_source\"],\"sort\":[\"@timestamp\",\"desc\"]}]", visualizationResponse.Id, searchResponse.Id)).
 		WithOptionsJson("{\"darkTheme\":false}").
-		WithUiStateJson("{\"P-1\":{\"vis\":{\"defaultColors\":{\"0 - 50\":\"rgb(0,104,55)\",\"50 - 75\":\"rgb(255,255,190)\",\"75 - 100\":\"rgb(165,0,38)\"}}}}").
 		Build()
 
 	assert.Nil(t, err)
 
 	response, err := dashboardApi.Create(dashboardRequest)
+	assert.Nil(t, err)
+
 	defer dashboardApi.Delete(response.Id)
 
 	assert.Nil(t, err)
@@ -64,7 +68,6 @@ func Test_DashboardRead(t *testing.T) {
 		WithDescription("This dashboard shows errors from china").
 		WithPanelsJson("[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"bc8a1970-175b-11e8-accb-65182aaf9591\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"search\",\"id\":\"aca8b340-175b-11e8-accb-65182aaf9591\",\"col\":7,\"row\":1,\"columns\":[\"_source\"],\"sort\":[\"@timestamp\",\"desc\"]}]").
 		WithOptionsJson("{\"darkTheme\":false}").
-		WithUiStateJson("{\"P-1\":{\"vis\":{\"defaultColors\":{\"0 - 50\":\"rgb(0,104,55)\",\"50 - 75\":\"rgb(255,255,190)\",\"75 - 100\":\"rgb(165,0,38)\"}}}}").
 		Build()
 
 	assert.Nil(t, err)
@@ -109,12 +112,12 @@ func Test_DashboardUpdate(t *testing.T) {
 		WithDescription("This dashboard shows errors from china").
 		WithPanelsJson("[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"bc8a1970-175b-11e8-accb-65182aaf9591\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"search\",\"id\":\"aca8b340-175b-11e8-accb-65182aaf9591\",\"col\":7,\"row\":1,\"columns\":[\"_source\"],\"sort\":[\"@timestamp\",\"desc\"]}]").
 		WithOptionsJson("{\"darkTheme\":false}").
-		WithUiStateJson("{\"P-1\":{\"vis\":{\"defaultColors\":{\"0 - 50\":\"rgb(0,104,55)\",\"50 - 75\":\"rgb(255,255,190)\",\"75 - 100\":\"rgb(165,0,38)\"}}}}").
 		Build()
 
 	assert.Nil(t, err)
 
 	createdDashboard, err := dashboardApi.Create(request)
+	assert.Nil(t, err)
 	defer dashboardApi.Delete(createdDashboard.Id)
 	assert.Nil(t, err, "Error creating dashboard")
 

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -3,10 +3,12 @@ ARG ELK_PACK=-oss
 
 FROM docker.elastic.co/elasticsearch/elasticsearch$ELK_PACK:$ELK_VERSION
 
+ARG MAKELOGS_VERSION="makelogs@4.0.3"
+
 USER root
-RUN yum install -y openssl
+RUN yum install -y openssl wget
 RUN yum install -y epel-release && yum install -y nodejs && \
-    npm install -g makelogs@4.0.3
+    npm install -g $MAKELOGS_VERSION
 
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.1.3/dumb-init_1.1.3_amd64 && \
     chmod +x /usr/local/bin/dumb-init

--- a/docker/elasticsearch/entrypoint.sh
+++ b/docker/elasticsearch/entrypoint.sh
@@ -4,15 +4,37 @@ set -ex
 umask 0002
 
 run_as_other_user_if_needed() {
-    if [[ "$(id -u)" == "0" ]]; then
-        # If running as root, drop to specified UID and run command
-        exec chroot --userspec=1000 / "${@}"
-    else
-        # Either we are running in Openshift with random uid and are a member of the root group
-        # or with a custom --user
-        exec "${@}"
-    fi
+	if [[ "$(id -u)" == "0" ]]; then
+		# If running as root, drop to specified UID and run command
+		exec chroot --userspec=1000 / "${@}"
+	else
+		# Either we are running in Openshift with random uid and are a member of the root group
+		# or with a custom --user
+		exec "${@}"
+	fi
 }
 
+# Parse Docker env vars to customize Elasticsearch
+#
+# e.g. Setting the env var cluster.name=testcluster
+#
+# will cause Elasticsearch to be invoked with -Ecluster.name=testcluster
+#
+# see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#_setting_default_settings
+
+declare -a es_opts
+
+while IFS='=' read -r envvar_key envvar_value; do
+	# Elasticsearch settings need to have at least two dot separated lowercase
+	# words, e.g. `cluster.name`, except for `processors` which we handle
+	# specially
+	if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ || "$envvar_key" == "processors" ]]; then
+		if [[ ! -z $envvar_value ]]; then
+			es_opt="-E${envvar_key}=${envvar_value}"
+			es_opts+=("${es_opt}")
+		fi
+	fi
+done < <(env)
+
 exec /scripts/makelogs.sh &
-run_as_other_user_if_needed "$@"
+run_as_other_user_if_needed "$@" "${es_opts[@]}"

--- a/index_pattern.go
+++ b/index_pattern.go
@@ -57,14 +57,14 @@ type IndexPattern struct {
 type IndexPatternCreateResult struct {
 	Id         string                  `json:"id"`
 	Type       string                  `json:"type"`
-	Version    int                     `json:"version"`
+	Version    version                 `json:"version"`
 	Attributes *IndexPatternAttributes `json:"attributes"`
 }
 
 type IndexPatternCreateResult553 struct {
-	Id      string `json:"_id"`
-	Type    string `json:"_type"`
-	Version int    `json:"_version"`
+	Id      string  `json:"_id"`
+	Type    string  `json:"_type"`
+	Version version `json:"_version"`
 }
 
 type IndexPatternAttributes struct {
@@ -210,7 +210,7 @@ func (api *IndexPatternClient553) Create() (*IndexPatternCreateResult, error) {
 		return &IndexPatternCreateResult{
 			Id:      "logstash-*",
 			Type:    "index-pattern",
-			Version: 1,
+			Version: "1",
 		}, nil
 	} else if response.StatusCode >= 300 {
 		return nil, errors.New(fmt.Sprintf("Status: %d, %s", response.StatusCode, body))

--- a/kibana_client.go
+++ b/kibana_client.go
@@ -1,11 +1,13 @@
 package kibana
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/google/go-querystring/query"
@@ -24,6 +26,7 @@ const EnvLogzMfaSecret = "LOGZ_MFA_SECRET"
 const DefaultKibanaUri = "http://localhost:5601"
 const DefaultElasticSearchPath = "/es_admin/.kibana"
 const DefaultKibanaVersion6 = "6.0.0"
+const DefaultKibanaVersion7 = "7.3.1"
 const DefaultLogzioVersion = "6.3.2"
 const DefaultKibanaVersion553 = "5.5.3"
 const DefaultKibanaVersion = DefaultKibanaVersion6
@@ -53,6 +56,26 @@ func ParseKibanaType(value string) KibanaType {
 	return kibanaType
 }
 
+type version string
+
+func (v *version) UnmarshalJSON(data []byte) error {
+	var tmp int
+	err := json.Unmarshal(data, &tmp)
+	if err == nil {
+		*v = version(strconv.Itoa(tmp))
+		return nil
+	} else {
+		var tmp string
+		err = json.Unmarshal(data, &tmp)
+		if err != nil {
+			return err
+		} else {
+			*v = version(tmp)
+		}
+	}
+	return nil
+}
+
 type Config struct {
 	Debug             bool
 	DefaultIndexId    string
@@ -69,9 +92,9 @@ type KibanaClient struct {
 }
 
 type createResourceResult553 struct {
-	Id      string `json:"_id"`
-	Type    string `json:"_type"`
-	Version int    `json:"_version"`
+	Id      string  `json:"_id"`
+	Type    string  `json:"_type"`
+	Version version `json:"_version"`
 }
 
 var indexClientFromVersion = map[string]func(kibanaClient *KibanaClient) IndexPatternClient{

--- a/saved_objects.go
+++ b/saved_objects.go
@@ -28,7 +28,7 @@ type SavedObjectResponse struct {
 type SavedObject struct {
 	Id         string                 `json:"id"`
 	Type       string                 `json:"type"`
-	Version    int                    `json:"version"`
+	Version    version                `json:"version"`
 	Attributes map[string]interface{} `json:"attributes"`
 }
 

--- a/saved_objects_553.go
+++ b/saved_objects_553.go
@@ -50,15 +50,15 @@ func (api *savedObjectsClient553) GetByType(request *SavedObjectRequest) (*Saved
 
 	var savedObjects []*SavedObject
 	for _, item := range response.Hits.Hits {
-		version := 1
+		objectVersion := version("1")
 		if val, ok := item.Source["version"]; ok {
-			version = val.(int)
+			objectVersion = val.(version)
 		}
 
 		savedObjects = append(savedObjects, &SavedObject{
 			Type:       item.Type,
 			Id:         item.Id,
-			Version:    version,
+			Version:    objectVersion,
 			Attributes: item.Source,
 		})
 	}

--- a/saved_objects_600.go
+++ b/saved_objects_600.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/mcuadros/go-version"
+
+	goversion "github.com/mcuadros/go-version"
 )
 
 type savedObjectsClient600 struct {
@@ -39,7 +40,7 @@ func (api *savedObjectsClient600) GetByType(request *SavedObjectRequest) (*Saved
 }
 
 func (api *savedObjectsClient600) getSavedObjectsPath() string {
-	if version.Compare(api.config.KibanaVersion, "6.3.0", ">=") {
+	if goversion.Compare(api.config.KibanaVersion, "6.3.0", ">=") {
 		return api.config.KibanaBaseUri + savedObjectsPath + "_find"
 
 	}

--- a/search.go
+++ b/search.go
@@ -35,7 +35,7 @@ type UpdateSearchRequest struct {
 type Search struct {
 	Id         string            `json:"id"`
 	Type       string            `json:"type"`
-	Version    int               `json:"version"`
+	Version    version           `json:"version"`
 	Attributes *SearchAttributes `json:"attributes"`
 }
 
@@ -52,7 +52,7 @@ type SearchAttributes struct {
 type searchReadResult553 struct {
 	Id      string            `json:"_id"`
 	Type    string            `json:"_type"`
-	Version int               `json:"_version"`
+	Version version           `json:"_version"`
 	Source  *SearchAttributes `json:"_source"`
 }
 

--- a/search_553.go
+++ b/search_553.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/satori/go.uuid"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 type searchClient553 struct {

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -1,9 +1,10 @@
 package kibana
 
 import (
-	"github.com/satori/go.uuid"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_VisualizationCreateFromSavedSearch(t *testing.T) {
@@ -16,7 +17,7 @@ func Test_VisualizationCreateFromSavedSearch(t *testing.T) {
 		WithDescription("This visualization shows errors from china").
 		WithVisualizationState("{\"title\":\"test kong vis\",\"type\":\"area\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp date ranges\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_range\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"ranges\":[{\"from\":\"now-1h\",\"to\":\"now\"}]}}],\"listeners\":{}}").
 		WithSavedSearchId("123").
-		Build()
+		Build(client.Config.KibanaVersion)
 
 	assert.Nil(t, err)
 
@@ -40,7 +41,7 @@ func Test_VisualizationRead(t *testing.T) {
 		WithDescription("This visualization shows errors from china").
 		WithVisualizationState("{\"title\":\"test kong vis\",\"type\":\"area\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp date ranges\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_range\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"ranges\":[{\"from\":\"now-1h\",\"to\":\"now\"}]}}],\"listeners\":{}}").
 		WithSavedSearchId("123").
-		Build()
+		Build(client.Config.KibanaVersion)
 
 	assert.Nil(t, err)
 
@@ -83,7 +84,7 @@ func Test_VisualizationUpdate(t *testing.T) {
 		WithDescription("This visualization shows errors from china").
 		WithVisualizationState("{\"title\":\"test kong vis\",\"type\":\"area\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp date ranges\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_range\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"ranges\":[{\"from\":\"now-1h\",\"to\":\"now\"}]}}],\"listeners\":{}}").
 		WithSavedSearchId("123").
-		Build()
+		Build(client.Config.KibanaVersion)
 
 	assert.Nil(t, err)
 


### PR DESCRIPTION
The breaking changes we face are:

 - Version in most of api response are now strings (https://github.com/elastic/kibana/pull/30789)
 - Dashboard/Visualization API changes (https://www.elastic.co/guide/en/kibana/7.x/breaking-changes-7.0.html#breaking-changes-7.0-saved-objects)
 - Test data generated by elastic/makelogs@4.5.0 instead of makelogs@4.0.3