### PR TITLE
Add savedSearchRefName and KibanaSavedObjectMeta into Visualization.

### DIFF
--- a/vendor/github.com/ewilde/go-kibana/visualization.go
+++ b/vendor/github.com/ewilde/go-kibana/visualization.go
@@ -34,6 +34,7 @@ type VisualizationAttributes struct {
 	Version            int    `json:"version"`
 	VisualizationState string `json:"visState"`
 	SavedSearchId      string `json:"savedSearchId"`
+	SavedSearchRefName string `json:"savedSearchRefName"`
 }
 
 type VisualizationRequestBuilder struct {
@@ -41,6 +42,7 @@ type VisualizationRequestBuilder struct {
 	description        string
 	visualizationState string
 	savedSearchId      string
+	savedSearchRefName string
 }
 
 type visualizationClient600 struct {
@@ -84,6 +86,11 @@ func (builder *VisualizationRequestBuilder) WithSavedSearchId(savedSearchId stri
 	return builder
 }
 
+func (builder *VisualizationRequestBuilder) WithSavedSearchRefName(savedSearchRefName string) *VisualizationRequestBuilder {
+	builder.savedSearchRefName = savedSearchRefName
+	return builder
+}
+
 func (builder *VisualizationRequestBuilder) Build() (*CreateVisualizationRequest, error) {
 
 	return &CreateVisualizationRequest{
@@ -91,6 +98,7 @@ func (builder *VisualizationRequestBuilder) Build() (*CreateVisualizationRequest
 			Title:              builder.title,
 			Description:        builder.description,
 			SavedSearchId:      builder.savedSearchId,
+			SavedSearchRefName: builder.savedSearchRefName,
 			Version:            1,
 			VisualizationState: builder.visualizationState,
 		},

--- a/visualization.go
+++ b/visualization.go
@@ -105,8 +105,8 @@ func (builder *VisualizationRequestBuilder) WithSavedSearchRefName(savedSearchRe
 }
 
 func (builder *VisualizationRequestBuilder) WithKibanaSavedObjectMeta(meta *SearchKibanaSavedObjectMeta) *VisualizationRequestBuilder {
-        builder.kibanaSavedObjectMeta = meta
-        return builder
+	builder.kibanaSavedObjectMeta = meta
+	return builder
 }
 
 func (builder *VisualizationRequestBuilder) Build(version string) (*CreateVisualizationRequest, error) {

--- a/visualization.go
+++ b/visualization.go
@@ -40,18 +40,22 @@ type VisualizationReferences struct {
 }
 
 type VisualizationAttributes struct {
-	Title              string `json:"title"`
-	Description        string `json:"description"`
-	Version            int    `json:"version"`
-	VisualizationState string `json:"visState"`
-	SavedSearchId      string `json:"savedSearchId,omitempty"`
+	Title                 string                       `json:"title"`
+	Description           string                       `json:"description"`
+	Version               int                          `json:"version"`
+	VisualizationState    string                       `json:"visState"`
+	SavedSearchId         string                       `json:"savedSearchId,omitempty"`
+	SavedSearchRefName    string                       `json:"savedSearchRefName,omitempty"`
+	KibanaSavedObjectMeta *SearchKibanaSavedObjectMeta `json:"kibanaSavedObjectMeta"`
 }
 
 type VisualizationRequestBuilder struct {
-	title              string
-	description        string
-	visualizationState string
-	savedSearchId      string
+	title                 string
+	description           string
+	visualizationState    string
+	savedSearchId         string
+	savedSearchRefName    string
+	kibanaSavedObjectMeta *SearchKibanaSavedObjectMeta
 }
 
 type visualizationClient600 struct {
@@ -95,24 +99,37 @@ func (builder *VisualizationRequestBuilder) WithSavedSearchId(savedSearchId stri
 	return builder
 }
 
+func (builder *VisualizationRequestBuilder) WithSavedSearchRefName(savedSearchRefName string) *VisualizationRequestBuilder {
+	builder.savedSearchRefName = savedSearchRefName
+	return builder
+}
+
+func (builder *VisualizationRequestBuilder) WithKibanaSavedObjectMeta(meta *SearchKibanaSavedObjectMeta) *VisualizationRequestBuilder {
+        builder.kibanaSavedObjectMeta = meta
+        return builder
+}
+
 func (builder *VisualizationRequestBuilder) Build(version string) (*CreateVisualizationRequest, error) {
 	if goversion.Compare(version, "7.0.0", "<") {
 		return &CreateVisualizationRequest{
 			Attributes: &VisualizationAttributes{
-				Title:              builder.title,
-				Description:        builder.description,
-				SavedSearchId:      builder.savedSearchId,
-				Version:            1,
-				VisualizationState: builder.visualizationState,
+				Title:                 builder.title,
+				Description:           builder.description,
+				SavedSearchId:         builder.savedSearchId,
+				Version:               1,
+				VisualizationState:    builder.visualizationState,
+				KibanaSavedObjectMeta: builder.kibanaSavedObjectMeta,
 			},
 		}, nil
 	} else {
 		return &CreateVisualizationRequest{
 			Attributes: &VisualizationAttributes{
-				Title:              builder.title,
-				Description:        builder.description,
-				Version:            1,
-				VisualizationState: builder.visualizationState,
+				Title:                 builder.title,
+				Description:           builder.description,
+				Version:               1,
+				VisualizationState:    builder.visualizationState,
+				KibanaSavedObjectMeta: builder.kibanaSavedObjectMeta,
+				SavedSearchRefName:    "search_1",
 			},
 			References: []*VisualizationReferences{
 				{


### PR DESCRIPTION
Starting from Kibana 6.6 Visualizations and Dashboards are not displayed without  kibanaSavedObjectMeta.searchSourceJSON set.

Also SavedSearchRefName attribute is needed in Visualizations for Kibana 7.x.