### PR TITLE
Pedro gutierrez csrf parsing fix

### DIFF
--- a/logzio_authentication_handler.go
+++ b/logzio_authentication_handler.go
@@ -205,7 +205,7 @@ var (
 
 func findCsrfTokenInCookies(response gorequest.Response) (string, error) {
 	for _, cookie := range response.Header["Set-Cookie"] {
-		token, err := findCsrfTokenInCookieUsingRegexp(cookie, csrfRegexps)
+		token, err := findCsrfTokenInCookieUsingRegexps(cookie, csrfRegexps)
 		if err == nil && len(token) > 0 {
 			return token, nil
 		}
@@ -213,7 +213,7 @@ func findCsrfTokenInCookies(response gorequest.Response) (string, error) {
 	return "", errors.New("could not retrieve CSRF token from logz.io cookie")
 }
 
-func findCsrfTokenInCookieUsingRegexp(cookie string, regexps []*regexp.Regexp) (string, error) {
+func findCsrfTokenInCookieUsingRegexps(cookie string, regexps []*regexp.Regexp) (string, error) {
 	for _, regexp := range regexps {
 		matches := regexp.FindStringSubmatch(cookie)
 		if len(matches) > 1 {

--- a/logzio_authentication_handler.go
+++ b/logzio_authentication_handler.go
@@ -179,9 +179,8 @@ func (auth *LogzAuthenticationHandler) ChangeAccount(accountId string, agent *Ht
 
 func (auth *LogzAuthenticationHandler) getCSRFToken() (string, error) {
 
-	url := fmt.Sprintf("%s/#/login", auth.LogzUri)
 	request := gorequest.New()
-	response, _, errs := request.Get(url).
+	response, _, errs := request.Get(fmt.Sprintf("%s/#/login", auth.LogzUri)).
 		End()
 
 	if len(errs) > 0 {
@@ -193,7 +192,6 @@ func (auth *LogzAuthenticationHandler) getCSRFToken() (string, error) {
 		return "", err
 	}
 
-	fmt.Printf("csrf token %s", csrfToken)
 	auth.csrfToken = csrfToken
 	return csrfToken, nil
 }

--- a/logzio_authentication_handler.go
+++ b/logzio_authentication_handler.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/parnurzeal/gorequest"
-	"github.com/xlzd/gotp"
 	"log"
 	"regexp"
+
+	"github.com/parnurzeal/gorequest"
+	"github.com/xlzd/gotp"
 )
 
 const (
@@ -177,22 +178,52 @@ func (auth *LogzAuthenticationHandler) ChangeAccount(accountId string, agent *Ht
 }
 
 func (auth *LogzAuthenticationHandler) getCSRFToken() (string, error) {
+
+	url := fmt.Sprintf("%s/#/login", auth.LogzUri)
 	request := gorequest.New()
-	response, _, errs := request.Get(fmt.Sprintf("%s/#/login", auth.LogzUri)).
+	response, _, errs := request.Get(url).
 		End()
 
 	if len(errs) > 0 {
 		return "", errs[0]
 	}
-	cookieHeader := response.Header.Get("Set-Cookie")
-	csrfCookieRegEx := regexp.MustCompile("Logzio-Csrf=([^;]+)")
-	cookieRegExMatches := csrfCookieRegEx.FindStringSubmatch(cookieHeader)
-	if len(cookieRegExMatches) < 2 {
-		return "", errors.New("could not retrieve CSRF token from logz.io cookie")
+
+	csrfToken, err := findCsrfTokenInCookies(response)
+	if err != nil {
+		return "", err
 	}
-	csrfToken := cookieRegExMatches[1]
+
+	fmt.Printf("csrf token %s", csrfToken)
 	auth.csrfToken = csrfToken
 	return csrfToken, nil
+}
+
+var (
+	csrfRegexps = []*regexp.Regexp{
+		regexp.MustCompile("Logzio-Csrf=([^;]+)"),
+		regexp.MustCompile("Logzio-Csrf-V2=([^;]+)"),
+	}
+)
+
+func findCsrfTokenInCookies(response gorequest.Response) (string, error) {
+	for _, cookie := range response.Header["Set-Cookie"] {
+		token, err := findCsrfTokenInCookieUsingRegexp(cookie, csrfRegexps)
+		if err == nil && len(token) > 0 {
+			return token, nil
+		}
+	}
+	return "", errors.New("could not retrieve CSRF token from logz.io cookie")
+}
+
+func findCsrfTokenInCookieUsingRegexp(cookie string, regexps []*regexp.Regexp) (string, error) {
+	for _, regexp := range regexps {
+		matches := regexp.FindStringSubmatch(cookie)
+		if len(matches) > 1 {
+			return matches[1], nil
+		}
+	}
+
+	return "", fmt.Errorf("Cookie %s didn't match %v", cookie, regexps)
 }
 
 func (auth *LogzAuthenticationHandler) getLogzioSessionToken(retry bool) (sessionToken string, err error) {


### PR DESCRIPTION
Fix a potential error while parsing the csrf token if the order of cookies returned by logz is unexpected. Eg:

```
$ curl https://app-uk.logz.io/\#/login -i 
HTTP/2 200 
content-type: text/html; charset=UTF-8
x-frame-options: sameorigin
last-modified: Mon, 16 Nov 2020 11:47:56 GMT
etag: W/"fa9-175d0e20ace"
cache-control: public, max-age=0
date: Mon, 16 Nov 2020 20:47:58 GMT
content-length: 4009
set-cookie: Logzio-Csrf-V2=jRs8RnQPv77vzSmztRZCfuIKjkeCn-eNTgQE0jcZ0Ge; Secure; SameSite=None; Domain=logz.io; Path=/
set-cookie: Logzio-Csrf=jRs8RnQPv77vzSmztRZCfuIKjkeCn-eNTgQE0jcZ0Ge; Secure; SameSite=None
```