### PR TITLE
fix kibana version in use by logz.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 env:
   matrix:
   - ELK_VERSION=5.5.3 KIBANA_TYPE=KibanaTypeVanilla ELASTIC_PACK= MAKELOGS_VERSION=makelogs@4.0.3
-  - ELK_VERSION=6.3.2 KIBANA_TYPE=KibanaTypeLogzio KIBANA_URI=https://app-eu.logz.io ELASTIC_SEARCH_PATH=/kibana/elasticsearch/logzioCustomerKibanaIndex LOGZ_IO_ACCOUNT_ID_1=16533 LOGZ_IO_ACCOUNT_ID_2=14942
+  - ELK_VERSION=7.3.1 KIBANA_TYPE=KibanaTypeLogzio KIBANA_URI=https://app-eu.logz.io ELASTIC_SEARCH_PATH=/kibana/elasticsearch/logzioCustomerKibanaIndex LOGZ_IO_ACCOUNT_ID_1=16533 LOGZ_IO_ACCOUNT_ID_2=14942
   - ELK_VERSION=6.2.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=makelogs@4.0.3
   - ELK_VERSION=6.4.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=makelogs@4.0.3
   - ELK_VERSION=7.3.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=@elastic/makelogs@4.5.0


### PR DESCRIPTION
Fix the Kibana version to the one currently reported by Logz.io.

This avoids having errors such as:

```
Browser client is out of date, please refresh the page
```

in the tests.