### PR TITLE
Use Kibana 7.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 env:
   matrix:
   - ELK_VERSION=5.5.3 KIBANA_TYPE=KibanaTypeVanilla ELASTIC_PACK= MAKELOGS_VERSION=makelogs@4.0.3
-  - ELK_VERSION=7.3.1 KIBANA_TYPE=KibanaTypeLogzio KIBANA_URI=https://app-eu.logz.io ELASTIC_SEARCH_PATH=/kibana/elasticsearch/logzioCustomerKibanaIndex LOGZ_IO_ACCOUNT_ID_1=16533 LOGZ_IO_ACCOUNT_ID_2=14942
+  - ELK_VERSION=7.2.1 KIBANA_TYPE=KibanaTypeLogzio KIBANA_URI=https://app-eu.logz.io ELASTIC_SEARCH_PATH=/kibana/elasticsearch/logzioCustomerKibanaIndex LOGZ_IO_ACCOUNT_ID_1=16533 LOGZ_IO_ACCOUNT_ID_2=14942
   - ELK_VERSION=6.2.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=makelogs@4.0.3
   - ELK_VERSION=6.4.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=makelogs@4.0.3
   - ELK_VERSION=7.3.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=@elastic/makelogs@4.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 env:
   matrix:
   - ELK_VERSION=5.5.3 KIBANA_TYPE=KibanaTypeVanilla ELASTIC_PACK= MAKELOGS_VERSION=makelogs@4.0.3
-  - ELK_VERSION=6.3.2 KIBANA_TYPE=KibanaTypeLogzio KIBANA_URI=https://app-eu.logz.io ELASTIC_SEARCH_PATH=/kibana/elasticsearch/logzioCustomerKibanaIndex LOGZ_IO_ACCOUNT_ID_1=16533 LOGZ_IO_ACCOUNT_ID_2=14942
+  - ELK_VERSION=7.3.1 KIBANA_TYPE=KibanaTypeLogzio KIBANA_URI=https://app-eu.logz.io ELASTIC_SEARCH_PATH=/kibana/elasticsearch/logzioCustomerKibanaIndex LOGZ_IO_ACCOUNT_ID_1=16533 LOGZ_IO_ACCOUNT_ID_2=14942
   - ELK_VERSION=6.2.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=makelogs@4.0.3
   - ELK_VERSION=6.4.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=makelogs@4.0.3
   - ELK_VERSION=7.3.1 KIBANA_TYPE=KibanaTypeVanilla MAKELOGS_VERSION=@elastic/makelogs@4.5.0


### PR DESCRIPTION
In my previous PR the Kibana version was incorrectly set to 7.3.1. 
With 7.2.1 all tests pass locally. 
This is also the version used by Logz.io at the moment:

<img width="322" alt="image" src="https://user-images.githubusercontent.com/12581/99718146-c0a86380-2aaa-11eb-9f69-2c5110e050f6.png">


```
✗ go test -v              
=== RUN   Test_DashboardCreateFromSavedSearch
--- PASS: Test_DashboardCreateFromSavedSearch (4.55s)
=== RUN   Test_DashboardRead
--- PASS: Test_DashboardRead (0.35s)
=== RUN   Test_DashboardRead_Unknown_Dashboard_Returns_404
--- PASS: Test_DashboardRead_Unknown_Dashboard_Returns_404 (0.14s)
=== RUN   Test_DashboardUpdate
--- PASS: Test_DashboardUpdate (0.39s)
=== RUN   Test_NewClient
--- PASS: Test_NewClient (0.00s)
=== RUN   Test_Change_account
--- PASS: Test_Change_account (3.20s)
=== RUN   Test_LogzAuthentication_handler
--- PASS: Test_LogzAuthentication_handler (2.38s)
=== RUN   Test_RoleGet
    Test_RoleGet: testing.go:150: Skipping testing as we don't have xpack security
--- SKIP: Test_RoleGet (0.00s)
=== RUN   Test_RolePutEmpty
    Test_RolePutEmpty: testing.go:150: Skipping testing as we don't have xpack security
--- SKIP: Test_RolePutEmpty (0.00s)
=== RUN   Test_RolePutBasic
    Test_RolePutBasic: testing.go:150: Skipping testing as we don't have xpack security
--- SKIP: Test_RolePutBasic (0.00s)
=== RUN   Test_RoleDeleteBasic
    Test_RoleDeleteBasic: testing.go:150: Skipping testing as we don't have xpack security
--- SKIP: Test_RoleDeleteBasic (0.00s)
=== RUN   Test_SavedObjectsGetByType
--- PASS: Test_SavedObjectsGetByType (0.63s)
=== RUN   Test_SavedObjectsGetByType_with_multiple_fields
--- PASS: Test_SavedObjectsGetByType_with_multiple_fields (0.17s)
=== RUN   Test_SearchCreate
--- PASS: Test_SearchCreate (0.25s)
=== RUN   Test_SearchCreate_with_exists_field
--- PASS: Test_SearchCreate_with_exists_field (0.26s)
=== RUN   Test_SearchCreate_with_two_filters
--- PASS: Test_SearchCreate_with_two_filters (0.26s)
=== RUN   Test_SearchCreate_with_query
--- PASS: Test_SearchCreate_with_query (0.24s)
=== RUN   Test_SearchRead
--- PASS: Test_SearchRead (0.39s)
=== RUN   Test_SearchRead_Unknown_Search_Returns_404
--- PASS: Test_SearchRead_Unknown_Search_Returns_404 (0.14s)
=== RUN   Test_SearchUpdate
--- PASS: Test_SearchUpdate (0.37s)
=== RUN   Test_SearchDelete
--- PASS: Test_SearchDelete (0.34s)
=== RUN   Test_SpaceGet
    Test_SpaceGet: testing.go:150: Skipping testing as we don't have xpack security
--- SKIP: Test_SpaceGet (0.00s)
=== RUN   Test_SpacePostEmpty
    Test_SpacePostEmpty: testing.go:150: Skipping testing as we don't have xpack security
--- SKIP: Test_SpacePostEmpty (0.00s)
=== RUN   Test_SpacePostBasic
    Test_SpacePostBasic: testing.go:150: Skipping testing as we don't have xpack security
--- SKIP: Test_SpacePostBasic (0.00s)
=== RUN   Test_SpaceDeleteBasic
    Test_SpaceDeleteBasic: testing.go:150: Skipping testing as we don't have xpack security
--- SKIP: Test_SpaceDeleteBasic (0.00s)
=== RUN   Test_SpaceUpdateBasic
    Test_SpaceUpdateBasic: testing.go:150: Skipping testing as we don't have xpack security
--- SKIP: Test_SpaceUpdateBasic (0.00s)
=== RUN   Test_VisualizationCreateFromSavedSearch
--- PASS: Test_VisualizationCreateFromSavedSearch (0.26s)
=== RUN   Test_VisualizationRead
--- PASS: Test_VisualizationRead (0.43s)
=== RUN   Test_VisualizationRead_Unknown_Visualization_Returns_404
--- PASS: Test_VisualizationRead_Unknown_Visualization_Returns_404 (0.11s)
=== RUN   Test_VisualizationUpdate
--- PASS: Test_VisualizationUpdate (0.38s)
PASS
ok  	github.com/ewilde/go-kibana	15.450s
```