### PR TITLE
Allow visualizations to be set with references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 .idea/
+
+.env

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.3.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.3.0
 	github.com/xlzd/gotp v0.0.0-20181030022105-c8557ba2c119
 	golang.org/x/sys v0.0.0-20190310054646-10058d7d4faa // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/cenkalti/backoff v2.1.1+incompatible h1:tKJnvO2kl0zmb/jA5UKAt4VoEVw1q
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 h1:4BX8f882bXEDKfWIf0wa8HRvpnBoPszJJXL+TVbBw4M=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -64,9 +65,12 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/xlzd/gotp v0.0.0-20181030022105-c8557ba2c119 h1:YyPWX3jLOtYKulBR6AScGIs74lLrJcgeKRwcbAuQOG4=
 github.com/xlzd/gotp v0.0.0-20181030022105-c8557ba2c119/go.mod h1:/nuTSlK+okRfR/vnIPqR89fFKonnWPiZymN5ydRJkX8=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/visualization.go
+++ b/visualization.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	VisualizationReferencesTypeSearch visualizationReferencesType = "search"
-	VisualizationReferencesTypeIndex  visualizationReferencesType = "index"
+	VisualizationReferencesTypeSearch       visualizationReferencesType = "search"
+	VisualizationReferencesTypeIndexPattern visualizationReferencesType = "index-pattern"
 )
 
 type visualizationReferencesType string

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -51,7 +51,7 @@ func Test_VisualizationCreateWithReferences(t *testing.T) {
 		{
 			Id:   "456",
 			Name: "TestIndex",
-			Type: VisualizationReferencesTypeIndex,
+			Type: VisualizationReferencesTypeIndexPattern,
 		},
 		{
 			Id:   "789",
@@ -75,7 +75,7 @@ func Test_VisualizationCreateWithReferences(t *testing.T) {
 	assert.NotEmpty(t, response.References)
 	assert.Equal(t, "456", response.References[0].Id)
 	assert.Equal(t, "TestIndex", response.References[0].Name)
-	assert.Equal(t, VisualizationReferencesTypeIndex, response.References[0].Type)
+	assert.Equal(t, VisualizationReferencesTypeIndexPattern, response.References[0].Type)
 	assert.Equal(t, "789", response.References[1].Id)
 	assert.Equal(t, "TestSearch", response.References[1].Name)
 	assert.Equal(t, VisualizationReferencesTypeSearch, response.References[1].Type)

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -8,18 +8,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func newTestVisualizationRequestBuilder() *VisualizationRequestBuilder {
+	builder := NewVisualizationRequestBuilder().
+		WithTitle("China errors").
+		WithDescription("This visualization shows errors from china").
+		WithVisualizationState("{\"title\":\"test kong vis\",\"type\":\"area\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp date ranges\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_range\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"ranges\":[{\"from\":\"now-1h\",\"to\":\"now\"}]}}],\"listeners\":{}}").
+		WithSavedSearchId("123")
+
+	return builder
+}
+
 func Test_VisualizationCreateFromSavedSearch(t *testing.T) {
 	client := DefaultTestKibanaClient()
 
 	visualizationApi := client.Visualization()
 
-	request, err := NewVisualizationRequestBuilder().
-		WithTitle("China errors").
-		WithDescription("This visualization shows errors from china").
-		WithVisualizationState("{\"title\":\"test kong vis\",\"type\":\"area\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp date ranges\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_range\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"ranges\":[{\"from\":\"now-1h\",\"to\":\"now\"}]}}],\"listeners\":{}}").
-		WithSavedSearchId("123").
+	request, err := newTestVisualizationRequestBuilder().
 		Build(client.Config.KibanaVersion)
-
 	assert.Nil(t, err)
 
 	response, err := visualizationApi.Create(request)
@@ -33,17 +38,51 @@ func Test_VisualizationCreateFromSavedSearch(t *testing.T) {
 	assert.Equal(t, request.Attributes.SavedSearchId, response.Attributes.SavedSearchId)
 }
 
+func Test_VisualizationCreateWithReferences(t *testing.T) {
+	client := DefaultTestKibanaClient()
+
+	visualizationApi := client.Visualization()
+
+	builder := newTestVisualizationRequestBuilder()
+	builder.WithReferences([]*VisualizationReferences{
+		{
+			Id:   "456",
+			Name: "TestIndex",
+			Type: VisualizationReferencesTypeIndex,
+		},
+		{
+			Id:   "789",
+			Name: "TestSearch",
+			Type: VisualizationReferencesTypeSearch,
+		},
+	})
+	request, err := builder.
+		Build(client.Config.KibanaVersion)
+	assert.Nil(t, err)
+
+	response, err := visualizationApi.Create(request)
+	defer visualizationApi.Delete(response.Id)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, request.Attributes.Title, response.Attributes.Title)
+	assert.Equal(t, request.Attributes.VisualizationState, response.Attributes.VisualizationState)
+	assert.Equal(t, request.Attributes.Version, response.Attributes.Version)
+	assert.Equal(t, "", response.Attributes.SavedSearchId)
+	assert.Equal(t, "456", response.References[0].Id)
+	assert.Equal(t, "TestIndex", response.References[0].Name)
+	assert.Equal(t, VisualizationReferencesTypeIndex, response.References[0].Type)
+	assert.Equal(t, "789", response.References[1].Id)
+	assert.Equal(t, "TestSearch", response.References[1].Name)
+	assert.Equal(t, VisualizationReferencesTypeSearch, response.References[1].Type)
+}
+
 func Test_VisualizationRead(t *testing.T) {
 	client := DefaultTestKibanaClient()
 	visualizationApi := client.Visualization()
 
-	request, err := NewVisualizationRequestBuilder().
-		WithTitle("China errors").
-		WithDescription("This visualization shows errors from china").
-		WithVisualizationState("{\"title\":\"test kong vis\",\"type\":\"area\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp date ranges\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_range\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"ranges\":[{\"from\":\"now-1h\",\"to\":\"now\"}]}}],\"listeners\":{}}").
-		WithSavedSearchId("123").
+	request, err := newTestVisualizationRequestBuilder().
 		Build(client.Config.KibanaVersion)
-
 	assert.Nil(t, err)
 
 	createdVisualization, err := visualizationApi.Create(request)
@@ -81,16 +120,10 @@ func Test_VisualizationList(t *testing.T) {
 	if goversion.Compare(client.Config.KibanaVersion, "6.3.0", "<") {
 		t.SkipNow()
 	}
-
 	visualizationApi := client.Visualization()
 
-	request, err := NewVisualizationRequestBuilder().
-		WithTitle("China errors").
-		WithDescription("This visualization shows errors from china").
-		WithVisualizationState("{\"title\":\"test kong vis\",\"type\":\"area\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp date ranges\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_range\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"ranges\":[{\"from\":\"now-1h\",\"to\":\"now\"}]}}],\"listeners\":{}}").
-		WithSavedSearchId("123").
+	request, err := newTestVisualizationRequestBuilder().
 		Build(client.Config.KibanaVersion)
-
 	assert.Nil(t, err)
 
 	createdVisualization, err := visualizationApi.Create(request)
@@ -107,13 +140,8 @@ func Test_VisualizationUpdate(t *testing.T) {
 	client := DefaultTestKibanaClient()
 	visualizationApi := client.Visualization()
 
-	request, err := NewVisualizationRequestBuilder().
-		WithTitle("China errors").
-		WithDescription("This visualization shows errors from china").
-		WithVisualizationState("{\"title\":\"test kong vis\",\"type\":\"area\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp date ranges\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_range\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"ranges\":[{\"from\":\"now-1h\",\"to\":\"now\"}]}}],\"listeners\":{}}").
-		WithSavedSearchId("123").
+	request, err := newTestVisualizationRequestBuilder().
 		Build(client.Config.KibanaVersion)
-
 	assert.Nil(t, err)
 
 	createdVisualization, err := visualizationApi.Create(request)

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -68,7 +68,7 @@ func Test_VisualizationCreateWithReferences(t *testing.T) {
 	assert.Equal(t, request.Attributes.Title, response.Attributes.Title)
 	assert.Equal(t, request.Attributes.VisualizationState, response.Attributes.VisualizationState)
 	assert.Equal(t, request.Attributes.Version, response.Attributes.Version)
-	assert.Equal(t, "", response.Attributes.SavedSearchId)
+	assert.Equal(t, request.Attributes.SavedSearchId, response.Attributes.SavedSearchId)
 	assert.Equal(t, "456", response.References[0].Id)
 	assert.Equal(t, "TestIndex", response.References[0].Name)
 	assert.Equal(t, VisualizationReferencesTypeIndex, response.References[0].Type)

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -40,6 +40,9 @@ func Test_VisualizationCreateFromSavedSearch(t *testing.T) {
 
 func Test_VisualizationCreateWithReferences(t *testing.T) {
 	client := DefaultTestKibanaClient()
+	if goversion.Compare(client.Config.KibanaVersion, "7.0.0", "<") {
+		t.SkipNow()
+	}
 
 	visualizationApi := client.Visualization()
 
@@ -68,7 +71,8 @@ func Test_VisualizationCreateWithReferences(t *testing.T) {
 	assert.Equal(t, request.Attributes.Title, response.Attributes.Title)
 	assert.Equal(t, request.Attributes.VisualizationState, response.Attributes.VisualizationState)
 	assert.Equal(t, request.Attributes.Version, response.Attributes.Version)
-	assert.Equal(t, request.Attributes.SavedSearchId, response.Attributes.SavedSearchId)
+	assert.Equal(t, "", response.Attributes.SavedSearchId)
+	assert.NotEmpty(t, response.References)
 	assert.Equal(t, "456", response.References[0].Id)
 	assert.Equal(t, "TestIndex", response.References[0].Name)
 	assert.Equal(t, VisualizationReferencesTypeIndex, response.References[0].Type)


### PR DESCRIPTION
Currently, visualizations for Kibana versions >= 7.0.0 are hard-coded with 1 reference of type "search", but the Kibana version does actually support having multiple references of both type "search" or "index. This PR allows multiple references with the supported types to be set for visualizations.