### PR TITLE
Fix multi format sort for search attributes

### DIFF
--- a/examples/visualization.go
+++ b/examples/visualization.go
@@ -11,7 +11,7 @@ func createVisualization(search *kibana.Search) (*kibana.Visualization, error) {
 		WithDescription("Gauge visualization based on a saved search").
 		WithVisualizationState(`{"title":"Chinese search","type":"gauge","params":{"type":"gauge","addTooltip":true,"addLegend":true,"gauge":{"verticalSplit":false,"extendRange":true,"percentageMode":false,"gaugeType":"Arc","gaugeStyle":"Full","backStyle":"Full","orientation":"vertical","colorSchema":"Green to Red","gaugeColorMode":"Labels","colorsRange":[{"from":0,"to":50},{"from":50,"to":75},{"from":75,"to":100}],"invertColors":false,"labels":{"show":true,"color":"black"},"scale":{"show":true,"labels":false,"color":"#333"},"type":"meter","style":{"bgWidth":0.9,"width":0.9,"mask":false,"bgMask":false,"maskBars":50,"bgFill":"#eee","bgColor":false,"subText":"","fontSize":60,"labelColor":true}}},"aggs":[{"id":"1","enabled":true,"type":"count","schema":"metric","params":{}}]}`).
 		WithSavedSearchId(search.Id).
-		Build()
+		Build(client.Config.KibanaVersion)
 
 	return client.Visualization().Create(request)
 }

--- a/search_test.go
+++ b/search_test.go
@@ -9,6 +9,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_SortUnmarshalJSON(t *testing.T) {
+	s := &Sort{}
+	err := json.Unmarshal([]byte(`["@timestamp", "desc"]`), s)
+	assert.NoError(t, err)
+	assert.Equal(t, &Sort{"@timestamp", "desc"}, s)
+
+	s = &Sort{}
+	err = json.Unmarshal([]byte(`[["@name", "desc"]]`), s)
+	assert.NoError(t, err)
+	assert.Equal(t, &Sort{"@name", "desc"}, s)
+}
+
 func Test_SearchCreate(t *testing.T) {
 	client := DefaultTestKibanaClient()
 	searchApi := client.Search()


### PR DESCRIPTION
In newer version of Kibana (>= 7.4.0), the sort field can be a nested array. This PR add supports for the newer format and convert it to the older format on read.

Closes #37