### PR TITLE
Add support for dashboard references

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -8,6 +8,18 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// Enums for DashboardReferencesType
+const (
+	DashboardReferencesTypeSearch        dashboardReferencesType = "search"
+	DashboardReferencesTypeVisualization dashboardReferencesType = "visualization"
+)
+
+type dashboardReferencesType string
+
+func (r dashboardReferencesType) String() string {
+	return string(r)
+}
+
 type DashboardClient interface {
 	Create(request *CreateDashboardRequest) (*Dashboard, error)
 	GetById(id string) (*Dashboard, error)
@@ -17,18 +29,27 @@ type DashboardClient interface {
 }
 
 type CreateDashboardRequest struct {
-	Attributes *DashboardAttributes `json:"attributes"`
+	Attributes *DashboardAttributes   `json:"attributes"`
+	References []*DashboardReferences `json:"references,omitempty"`
 }
 
 type UpdateDashboardRequest struct {
-	Attributes *DashboardAttributes `json:"attributes"`
+	Attributes *DashboardAttributes   `json:"attributes"`
+	References []*DashboardReferences `json:"references,omitempty"`
 }
 
 type Dashboard struct {
-	Id         string               `json:"id"`
-	Type       string               `json:"type"`
-	Version    version              `json:"version"`
-	Attributes *DashboardAttributes `json:"attributes"`
+	Id         string                 `json:"id"`
+	Type       string                 `json:"type"`
+	Version    version                `json:"version"`
+	Attributes *DashboardAttributes   `json:"attributes"`
+	References []*DashboardReferences `json:"references,omitempty"`
+}
+
+type DashboardReferences struct {
+	Name string                  `json:"name"`
+	Type dashboardReferencesType `json:"type"`
+	Id   string                  `json:"id"`
 }
 
 type DashboardAttributes struct {
@@ -50,6 +71,7 @@ type DashboardRequestBuilder struct {
 	uiStateJson           string
 	timeRestore           bool
 	kibanaSavedObjectMeta *SearchKibanaSavedObjectMeta
+	references            []*DashboardReferences
 }
 
 type dashboardClient600 struct {
@@ -108,6 +130,11 @@ func (builder *DashboardRequestBuilder) WithKibanaSavedObjectMeta(meta *SearchKi
 	return builder
 }
 
+func (builder *DashboardRequestBuilder) WithReferences(refs []*DashboardReferences) *DashboardRequestBuilder {
+	builder.references = refs
+	return builder
+}
+
 func (builder *DashboardRequestBuilder) Build() (*CreateDashboardRequest, error) {
 
 	return &CreateDashboardRequest{
@@ -120,6 +147,7 @@ func (builder *DashboardRequestBuilder) Build() (*CreateDashboardRequest, error)
 			TimeRestore:           builder.timeRestore,
 			KibanaSavedObjectMeta: builder.kibanaSavedObjectMeta,
 		},
+		References: builder.references,
 	}, nil
 }
 

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func newTestDashboardRequestBuilder(visID, searchID string) *DashboardRequestBuilder {
+	builder := NewDashboardRequestBuilder().
+		WithTitle("China errors").
+		WithDescription("This dashboard shows errors from china").
+		WithPanelsJson(fmt.Sprintf("[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"%s\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"search\",\"id\":\"%s\",\"col\":7,\"row\":1,\"columns\":[\"_source\"],\"sort\":[\"@timestamp\",\"desc\"]}]", visID, searchID)).
+		WithOptionsJson("{\"darkTheme\":false}")
+
+	return builder
+}
+
 func Test_DashboardCreateFromSavedSearch(t *testing.T) {
 	client := DefaultTestKibanaClient()
 
@@ -37,12 +47,7 @@ func Test_DashboardCreateFromSavedSearch(t *testing.T) {
 
 	dashboardApi := client.Dashboard()
 
-	dashboardRequest, err := NewDashboardRequestBuilder().
-		WithTitle("China errors").
-		WithDescription("This dashboard shows errors from china").
-		WithPanelsJson(fmt.Sprintf("[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"%s\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"search\",\"id\":\"%s\",\"col\":7,\"row\":1,\"columns\":[\"_source\"],\"sort\":[\"@timestamp\",\"desc\"]}]", visualizationResponse.Id, searchResponse.Id)).
-		WithOptionsJson("{\"darkTheme\":false}").
-		Build()
+	dashboardRequest, err := newTestDashboardRequestBuilder(visualizationResponse.Id, searchResponse.Id).Build()
 
 	assert.Nil(t, err)
 
@@ -83,11 +88,7 @@ func Test_DashboardCreateFromSavedSearchWithReferences(t *testing.T) {
 
 	dashboardApi := client.Dashboard()
 
-	dashboardRequest, err := NewDashboardRequestBuilder().
-		WithTitle("China errors").
-		WithDescription("This dashboard shows errors from china").
-		WithPanelsJson(fmt.Sprintf("[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"%s\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"search\",\"id\":\"%s\",\"col\":7,\"row\":1,\"columns\":[\"_source\"],\"sort\":[\"@timestamp\",\"desc\"]}]", visualizationResponse.Id, searchResponse.Id)).
-		WithOptionsJson("{\"darkTheme\":false}").
+	dashboardRequest, err := newTestDashboardRequestBuilder(visualizationResponse.Id, searchResponse.Id).
 		WithReferences([]*DashboardReferences{
 			{
 				Id:   visualizationResponse.Id,
@@ -129,12 +130,7 @@ func Test_DashboardRead(t *testing.T) {
 	client := DefaultTestKibanaClient()
 	dashboardApi := client.Dashboard()
 
-	request, err := NewDashboardRequestBuilder().
-		WithTitle("China errors").
-		WithDescription("This dashboard shows errors from china").
-		WithPanelsJson("[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"bc8a1970-175b-11e8-accb-65182aaf9591\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"search\",\"id\":\"aca8b340-175b-11e8-accb-65182aaf9591\",\"col\":7,\"row\":1,\"columns\":[\"_source\"],\"sort\":[\"@timestamp\",\"desc\"]}]").
-		WithOptionsJson("{\"darkTheme\":false}").
-		Build()
+	request, err := newTestDashboardRequestBuilder("bc8a1970-175b-11e8-accb-65182aaf9591", "aca8b340-175b-11e8-accb-65182aaf9591").Build()
 
 	assert.Nil(t, err)
 
@@ -177,12 +173,7 @@ func Test_DashboardList(t *testing.T) {
 
 	dashboardApi := client.Dashboard()
 
-	request, err := NewDashboardRequestBuilder().
-		WithTitle("China errors").
-		WithDescription("This dashboard shows errors from china").
-		WithPanelsJson("[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"bc8a1970-175b-11e8-accb-65182aaf9591\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"search\",\"id\":\"aca8b340-175b-11e8-accb-65182aaf9591\",\"col\":7,\"row\":1,\"columns\":[\"_source\"],\"sort\":[\"@timestamp\",\"desc\"]}]").
-		WithOptionsJson("{\"darkTheme\":false}").
-		Build()
+	request, err := newTestDashboardRequestBuilder("bc8a1970-175b-11e8-accb-65182aaf9591", "aca8b340-175b-11e8-accb-65182aaf9591").Build()
 
 	assert.Nil(t, err)
 
@@ -200,12 +191,7 @@ func Test_DashboardUpdate(t *testing.T) {
 	client := DefaultTestKibanaClient()
 	dashboardApi := client.Dashboard()
 
-	request, err := NewDashboardRequestBuilder().
-		WithTitle("China errors").
-		WithDescription("This dashboard shows errors from china").
-		WithPanelsJson("[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"bc8a1970-175b-11e8-accb-65182aaf9591\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"search\",\"id\":\"aca8b340-175b-11e8-accb-65182aaf9591\",\"col\":7,\"row\":1,\"columns\":[\"_source\"],\"sort\":[\"@timestamp\",\"desc\"]}]").
-		WithOptionsJson("{\"darkTheme\":false}").
-		Build()
+	request, err := newTestDashboardRequestBuilder("bc8a1970-175b-11e8-accb-65182aaf9591", "aca8b340-175b-11e8-accb-65182aaf9591").Build()
 
 	assert.Nil(t, err)
 

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -60,6 +60,71 @@ func Test_DashboardCreateFromSavedSearch(t *testing.T) {
 	assert.Equal(t, dashboardRequest.Attributes.Version, response.Attributes.Version)
 }
 
+func Test_DashboardCreateFromSavedSearchWithReferences(t *testing.T) {
+	client := DefaultTestKibanaClient()
+
+	searchClient := client.Search()
+	searchRequest, _, err := createSearchRequest(searchClient, client.Config.DefaultIndexId, t)
+	assert.Nil(t, err)
+	searchResponse, err := searchClient.Create(searchRequest)
+	assert.Nil(t, err)
+	defer searchClient.Delete(searchResponse.Id)
+
+	visualizationApi := client.Visualization()
+
+	builder := newTestVisualizationRequestBuilder()
+	request, err := builder.
+		WithSavedSearchId(searchResponse.Id).
+		Build(client.Config.KibanaVersion)
+	assert.Nil(t, err)
+
+	visualizationResponse, err := visualizationApi.Create(request)
+	defer visualizationApi.Delete(visualizationResponse.Id)
+
+	dashboardApi := client.Dashboard()
+
+	dashboardRequest, err := NewDashboardRequestBuilder().
+		WithTitle("China errors").
+		WithDescription("This dashboard shows errors from china").
+		WithPanelsJson(fmt.Sprintf("[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"%s\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"search\",\"id\":\"%s\",\"col\":7,\"row\":1,\"columns\":[\"_source\"],\"sort\":[\"@timestamp\",\"desc\"]}]", visualizationResponse.Id, searchResponse.Id)).
+		WithOptionsJson("{\"darkTheme\":false}").
+		WithReferences([]*DashboardReferences{
+			{
+				Id:   visualizationResponse.Id,
+				Name: "TestVisualization",
+				Type: DashboardReferencesTypeVisualization,
+			},
+			{
+				Id:   searchResponse.Id,
+				Name: "TestSearch",
+				Type: DashboardReferencesTypeSearch,
+			},
+		}).
+		Build()
+
+	assert.Nil(t, err)
+
+	response, err := dashboardApi.Create(dashboardRequest)
+	assert.Nil(t, err)
+
+	defer dashboardApi.Delete(response.Id)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, dashboardRequest.Attributes.Title, response.Attributes.Title)
+	assert.Equal(t, dashboardRequest.Attributes.PanelsJson, response.Attributes.PanelsJson)
+	assert.Equal(t, dashboardRequest.Attributes.OptionsJson, response.Attributes.OptionsJson)
+	assert.Equal(t, dashboardRequest.Attributes.UiStateJSON, response.Attributes.UiStateJSON)
+	assert.Equal(t, dashboardRequest.Attributes.Version, response.Attributes.Version)
+	assert.NotEmpty(t, response.References)
+	assert.Equal(t, visualizationResponse.Id, response.References[0].Id)
+	assert.Equal(t, "TestVisualization", response.References[0].Name)
+	assert.Equal(t, DashboardReferencesTypeVisualization, response.References[0].Type)
+	assert.Equal(t, searchResponse.Id, response.References[1].Id)
+	assert.Equal(t, "TestSearch", response.References[1].Name)
+	assert.Equal(t, DashboardReferencesTypeSearch, response.References[1].Type)
+}
+
 func Test_DashboardRead(t *testing.T) {
 	client := DefaultTestKibanaClient()
 	dashboardApi := client.Dashboard()


### PR DESCRIPTION
Seems like newer versions (not sure when) supports the use of references for the dashboard panels instead of embedding it inside the `panelJSON`. This PR add the support for dashboard references.