### PR TITLE
IndexRefName compatiable with 7.13.1

### DIFF
--- a/search.go
+++ b/search.go
@@ -119,7 +119,7 @@ type SearchKibanaSavedObjectMeta struct {
 
 type SearchSource struct {
 	IndexId      string          `json:"index"`
-	IndexRefName string          `json:"indexRefName"`
+	IndexRefName string          `json:"indexRefName,omitempty"`
 	HighlightAll bool            `json:"highlightAll"`
 	Version      bool            `json:"version"`
 	Query        interface{}     `json:"query,omitempty"`


### PR DESCRIPTION
For elastic 7.13.1, if we don't add omitempty, the created saved object can not be diplayed in kibana if IndexRefName is not specified.